### PR TITLE
Add flags for Cypress Tests

### DIFF
--- a/global-defaults/main.yaml
+++ b/global-defaults/main.yaml
@@ -4,3 +4,5 @@ metal_stack_cloud_ingress_dns:
 
 metal_stack_cloud_stripe_private_token: "{{ lookup('env', 'STRIPE_SECRET_KEY') | default('', true) }}"
 metal_stack_cloud_stripe_public_token: "{{ lookup('env', 'STRIPE_PUBLIC_KEY') | default('', true) }}"
+
+metal_stack_cloud_user_admittance: true

--- a/roles/api-server/files/api-server/templates/deployment.yaml
+++ b/roles/api-server/files/api-server/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
             value: "{{  .Values.api.sessionSecret }}"
           - name: FRONT_END_URL
             value: "{{  .Values.frontend.url }}"
+          - name: USER_ADMITTANCE
+            value: "{{ .Values.api.userAdmittance }}"
         args:
           - serve
           - --log-level={{ .Values.api.logLevel }}

--- a/roles/api-server/files/api-server/values.yaml
+++ b/roles/api-server/files/api-server/values.yaml
@@ -29,6 +29,7 @@ frontend:
 
 api:
   url: localhost
+  userAdmittance: true
   logLevel: info
   replicas: 2
   sessionSecret: secret

--- a/roles/api-server/templates/values.yaml
+++ b/roles/api-server/templates/values.yaml
@@ -23,6 +23,7 @@ frontend:
 
 api:
   url: "{{ api_server_http_url }}"
+  userAdmittance: "{{ metal_stack_cloud_user_admittance | lower }}"
   logLevel: "{{ api_server_log_level }}"
   replicas: "{{ api_server_replicas }}"
   sessionSecret: "{{ api_server_session_secret }}"

--- a/roles/console/defaults/main/main.yaml
+++ b/roles/console/defaults/main/main.yaml
@@ -4,9 +4,11 @@ console_replicas: 3
 
 console_api_url: https://api.{{ metal_stack_cloud_ingress_dns }}
 console_api_auth_callback_url: https://api.{{ metal_stack_cloud_ingress_dns }}/auth
+console_api_auth_test_callback_url: "{{ console_api_auth_callback_url }}/test/callback"
 console_stripe_public_key: "{{ metal_stack_cloud_stripe_public_token }}"
 
 console_user_admittance: true
+console_open_auth_test: false
 
 console_ingress_dns: console.{{ metal_stack_cloud_ingress_dns }}
 console_ingress_tls_enabled: false

--- a/roles/console/defaults/main/main.yaml
+++ b/roles/console/defaults/main/main.yaml
@@ -7,7 +7,7 @@ console_api_auth_callback_url: https://api.{{ metal_stack_cloud_ingress_dns }}/a
 console_api_auth_test_callback_url: "{{ console_api_auth_callback_url }}/test/callback"
 console_stripe_public_key: "{{ metal_stack_cloud_stripe_public_token }}"
 
-console_user_admittance: true
+metal_stack_cloud_user_admittance: true
 console_open_auth_test: false
 
 console_ingress_dns: console.{{ metal_stack_cloud_ingress_dns }}

--- a/roles/console/defaults/main/main.yaml
+++ b/roles/console/defaults/main/main.yaml
@@ -7,7 +7,6 @@ console_api_auth_callback_url: https://api.{{ metal_stack_cloud_ingress_dns }}/a
 console_api_auth_test_callback_url: "{{ console_api_auth_callback_url }}/test/callback"
 console_stripe_public_key: "{{ metal_stack_cloud_stripe_public_token }}"
 
-metal_stack_cloud_user_admittance: true
 console_open_auth_test: false
 
 console_ingress_dns: console.{{ metal_stack_cloud_ingress_dns }}

--- a/roles/console/templates/console-config.yaml
+++ b/roles/console/templates/console-config.yaml
@@ -1,7 +1,7 @@
 window.API_URL = "{{ console_api_url }}"
 window.AUTH_CALLBACK = "{{ console_api_auth_callback_url }}"
 window.STRIPE_PUBLIC_KEY = "{{ console_stripe_public_key }}"
-window.USER_ADMITTANCE = {{ console_user_admittance | lower }}
+window.USER_ADMITTANCE = {{ metal_stack_cloud_user_admittance | lower }}
 {% if console_open_auth_test %}
 window.OPEN_AUTH_TEST = true
 window.AUTH_TEST = "{{ console_api_auth_test_callback_url }}"

--- a/roles/console/templates/console-config.yaml
+++ b/roles/console/templates/console-config.yaml
@@ -1,4 +1,8 @@
 window.API_URL = "{{ console_api_url }}"
 window.AUTH_CALLBACK = "{{ console_api_auth_callback_url }}"
 window.STRIPE_PUBLIC_KEY = "{{ console_stripe_public_key }}"
-window.USER_ADMITTANCE = "{{ console_user_admittance }}"
+window.USER_ADMITTANCE = {{ console_user_admittance | lower }}
+{% if console_open_auth_test %}
+window.OPEN_AUTH_TEST = true
+window.AUTH_TEST = "{{ console_api_auth_test_callback_url }}"
+{% endif %}


### PR DESCRIPTION
I'd prefer running console cypress tests against my deployment using containers.

This Pull Request is part of a series:
- https://github.com/metal-stack-cloud/ansible-roles/pull/8
- https://github.com/metal-stack-cloud/deployment/pull/33
- https://github.com/metal-stack-cloud/console/pull/313

To test all three pull requests together, follow these steps:

1. check out all pull requests 
2. in `deployment/docker-compose.yml`, bind the volume `- ${HOME}/.ansible/roles/metal-stack-cloud-ansible-roles:/root/.ansible/roles/metal-stack-cloud-ansible-roles:ro` (adjusted to your local path)
3. in `deployment/group_vars/metal-stack-cloud/console.yaml`, set toggle the settings to `console_open_auth_test: true` and `console_user_admittance: false`
4. in deployment, run `make up` and wait until finished
5. if you open `http://console.172.17.0.1.nip.io:8080/login`, you should see the test login button and it should work
6. in `console`, run `make cypress-run-deployment` (Note: currently not all tests succeed, but the test login should)

