### PR TITLE
Optional duros config and object instead of string

### DIFF
--- a/roles/api-server/files/api-server/templates/deployment.yaml
+++ b/roles/api-server/files/api-server/templates/deployment.yaml
@@ -49,7 +49,9 @@ spec:
           - --auditing-index-keep={{ .Values.auditing.keep }}
           - --auditing-index-prefix={{ .Values.auditing.indexPrefix }}
           - --jwt-token-secret={{ .Values.api.jwtTokenSecret }}
+{{- if .Values.api.duros.config -}}
           - --duros-config-path=/duros/duros-config.yaml
+{{- end -}}
 {{- if .Values.gardener.kubeconfig }}
           - --gardener-kubeconfig=/gardener/kubeconfig
 {{- else }}

--- a/roles/api-server/files/api-server/templates/deployment.yaml
+++ b/roles/api-server/files/api-server/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - --auditing-index-keep={{ .Values.auditing.keep }}
           - --auditing-index-prefix={{ .Values.auditing.indexPrefix }}
           - --jwt-token-secret={{ .Values.api.jwtTokenSecret }}
-{{- if .Values.api.duros.config -}}
+{{- if .Values.api.duros.config }}
           - --duros-config-path=/duros/duros-config.yaml
 {{- end -}}
 {{- if .Values.gardener.kubeconfig }}

--- a/roles/api-server/files/api-server/templates/secrets.yaml
+++ b/roles/api-server/files/api-server/templates/secrets.yaml
@@ -15,7 +15,7 @@ metadata:
   name: duros-config
 type: Opaque
 data:
-  duros-config.yaml: {{ .Values.api.duros.config | b64enc }}
+  duros-config.yaml: {{ .Values.api.duros.config | toJson | b64enc }}
 {{- if .Values.gardener.kubeconfig }}
 ---
 apiVersion: v1

--- a/roles/api-server/files/api-server/values.yaml
+++ b/roles/api-server/files/api-server/values.yaml
@@ -89,17 +89,17 @@ api:
       cpu: "2"
 
   duros:
-    config: |
-      ---
-      eqx-mu4:
-        endpoints:
-          - "1.2.3.4"
-          - "1.2.3.5"
-        admintoken: admin-jwt-token
-        storageclasses:
-          - name: standard
-            replicas: 2
-            compression: true
+    config:
+      # ---
+      # eqx-mu4:
+      #   endpoints:
+      #     - "1.2.3.4"
+      #     - "1.2.3.5"
+      #   admintoken: admin-jwt-token
+      #   storageclasses:
+      #     - name: standard
+      #       replicas: 2
+      #       compression: true
 
 ingress:
   enabled: true

--- a/roles/api-server/templates/values.yaml
+++ b/roles/api-server/templates/values.yaml
@@ -62,8 +62,8 @@ api:
       {{ api_server_stripe_config | indent(width=6, first=false) }}
 
   duros:
-    config: |
-      {{ api_server_duros_config | indent(width=6, first=false) }}
+    config: 
+      {{ api_server_duros_config | to_json | indent(width=6, first=false) }}
 
 gardener:
   kubeconfig: |


### PR DESCRIPTION
Blocks: https://github.com/metal-stack-cloud/deployment/pull/37

Using objects instead of config files allows to see fields like ips in detail, while still being able to encrypt secrets like certs