### PR TITLE
Don't set restart policy for status dashboard container.

### DIFF
--- a/roles/status/templates/status.yaml
+++ b/roles/status/templates/status.yaml
@@ -48,7 +48,6 @@ spec:
           protocol: TCP
         - containerPort: 2112
           protocol: TCP
-        restartPolicy: Always
         volumeMounts:
         - mountPath: /etc/status
           name: config


### PR DESCRIPTION
Seems to be forbidden in newer K8s versions:

```
cloud  | TASK [metal-stack-cloud-ansible-roles/roles/status : Deploy status] ************
cloud  | fatal: [localhost]: FAILED! => changed=false 
cloud  |   msg: 'Failed to apply object: b''{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Deployment.apps \\"status-dashboard\\" is invalid: spec.template.spec.containers[0].restartPolicy: Forbidden: may not be set for non-init containers","reason":"Invalid","details":{"name":"status-dashboard","group":"apps","kind":"Deployment","causes":[{"reason":"FieldValueForbidden","message":"Forbidden: may not be set for non-init containers","field":"spec.template.spec.containers[0].restartPolicy"}]},"code":422}\n'''
```