### PR TITLE
Added backendprotocol grpc, grpcurl locally works fully now.

### DIFF
--- a/roles/api-server/files/api-server/templates/ingresses.yaml
+++ b/roles/api-server/files/api-server/templates/ingresses.yaml
@@ -6,6 +6,7 @@ metadata:
   name: api-server
   annotations:
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
 {{- if .Values.ingress.tls.enabled }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
 {{- else }}


### PR DESCRIPTION
I'm kind of confused when we use grpc and http. 
The reason I changed the ingress, is bc port forwarding the svc to locahost worked with grpcurl ==> So the ingress is broken.

Setting the annotation works, now calling the local api with grpcurl works fully. 

Like I said tho I'm not sure if this breaks anything?