### PR TITLE
Remove nested release vector from metalstack cloud release.

### DIFF
--- a/roles/defaults/defaults/main/main.yaml
+++ b/roles/defaults/defaults/main/main.yaml
@@ -1,8 +1,5 @@
 ---
 metal_stack_cloud_release:
-  nested:
-    - url_path: "vectors.metal-stack.url"
-      meta_var: "metal_stack_release"
   mapping:
     metal_stack_cloud_api_server_image_tag: "docker-images.metal-stack-cloud.api-server.tag"
     metal_stack_cloud_api_server_image_name: "docker-images.metal-stack-cloud.api-server.name"


### PR DESCRIPTION
The upcoming release does not contain this anymore.