### PR TITLE
Additional provider configuration options for virtual garden refresher

### DIFF
--- a/roles/api-server/files/api-server/values.yaml
+++ b/roles/api-server/files/api-server/values.yaml
@@ -158,3 +158,9 @@ virtualGardenKubeconfigRefresher:
     clusterName:
     serviceAccountJSON: |
       {}
+  metalStackCloud:
+    projectID:
+    apiToken:
+    clusterID:
+  static:
+    kubeconfig:

--- a/roles/api-server/templates/values.yaml
+++ b/roles/api-server/templates/values.yaml
@@ -133,3 +133,13 @@ virtualGardenKubeconfigRefresher:
     serviceAccountJSON: |
       {{ api_server_virtual_garden_kubeconfig_refresher_gcp_service_account_json | indent(width=6, first=false) }}
 {% endif %}
+{% if api_server_virtual_garden_kubeconfig_refresher_metal_stack_cloud_api_token %}
+  metalStackCloud:
+    projectID: "{{ api_server_virtual_garden_kubeconfig_refresher_metal_stack_cloud_project_id }}"
+    apiToken: "{{ api_server_virtual_garden_kubeconfig_refresher_metal_stack_cloud_api_token }}"
+    clusterID: "{{ api_server_virtual_garden_kubeconfig_refresher_metal_stack_cloud_cluster_id }}"
+{% endif %}
+{% if api_server_virtual_garden_kubeconfig_refresher_static_kubeconfig %}
+  static:
+    kubeconfig: "{{ api_server_virtual_garden_kubeconfig_refresher_static_kubeconfig }}"
+{% endif %}


### PR DESCRIPTION
This pull request adds the provider configuration options for using the `virtual-garden-kubeconfig-refresher` together with metalstack.cloud or a static kubeconfig.